### PR TITLE
Add rubocop config automatically

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -16,6 +16,7 @@ generate 'devise:views' if yes?('Install Devise view files?')
 #
 gem 'pundit'
 generate 'pundit:install'
+
 #
 # Seed an Administrative User
 #
@@ -106,6 +107,15 @@ gem_group :development, :test do
   gem 'sqlite3'
 end
 
+create_file 'config/rubocop.yml', "AllCops:
+  Exclude:
+    - 'db/**/*'
+    - 'bin/*'
+  TargetRubyVersion: 2.3"
+
+#
+# Test Only -
+#
 gem_group :test do
   gem 'capybara-webkit'
   gem 'capybara-screenshot'

--- a/template.rb
+++ b/template.rb
@@ -26,7 +26,7 @@ remove_file 'db/seeds.rb'
 # Create a new seeds file containing a user with a random password.
 create_file 'db/seeds.rb', "User.create!(
   email: 'webmaster@cts-llc.net', password: '#{SecureRandom.hex}'
-)"
+)\n"
 
 # Setup Static Home Page
 generate 'controller', 'static home'
@@ -111,7 +111,7 @@ create_file 'config/rubocop.yml', "AllCops:
   Exclude:
     - 'db/**/*'
     - 'bin/*'
-  TargetRubyVersion: 2.3"
+  TargetRubyVersion: 2.3\n"
 
 #
 # Test Only -


### PR DESCRIPTION
CI job trips over its absence on first run, should be added on setup.